### PR TITLE
Switched order of box-sizing and -moz-box-sizing

### DIFF
--- a/slick/slick.scss
+++ b/slick/slick.scss
@@ -3,8 +3,8 @@
 .slick-slider {
     position: relative;
     display: block;
-    box-sizing: border-box;
     -moz-box-sizing: border-box;
+    box-sizing: border-box;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;


### PR DESCRIPTION
Moved non-vendor-prefixed box-sizing to underneath prefixed version.
